### PR TITLE
Potential fix for code scanning alert no. 6: Information exposure through an exception

### DIFF
--- a/sdks/python/src/argyll/handlers.py
+++ b/sdks/python/src/argyll/handlers.py
@@ -156,8 +156,10 @@ def create_step_server(
 
         except HTTPError as e:
             return jsonify({"error": e.args[0]}), e.status_code
-        except Exception as e:
-            return jsonify({"error": str(e)}), 500
+        except Exception:
+            tb = traceback.format_exc()
+            print(f"Unhandled step server error: {tb}")
+            return jsonify({"error": "Internal server error"}), 500
 
     print(f"Starting step server: {step_id}")
     print(f"  Endpoint: {endpoint}")


### PR DESCRIPTION
Potential fix for [https://github.com/kode4food/argyll/security/code-scanning/6](https://github.com/kode4food/argyll/security/code-scanning/6)

In general, to fix this issue you should avoid sending raw exception text to the client. Instead, log the exception (including stack trace) on the server side, and return a generic, non-sensitive error message with an appropriate HTTP status code. This maintains observability for developers while preventing attackers from learning details about the internal implementation.

For this specific code, the best minimal fix is to modify the generic `except Exception as e:` block inside the `handle_step` route (lines 159–160). We will:

- Capture the full traceback using `traceback.format_exc()` (the module is already imported).
- Print or log this traceback on the server side.
- Return a generic error JSON such as `{"error": "Internal server error"}` with status code 500, instead of using `str(e)`.

We only need to change the handler function in `sdks/python/src/argyll/handlers.py`; no new imports or helper functions are strictly required because `traceback` is already imported at the top of the file. Functionality for clients remains the same in terms of contract (an error and HTTP 500), but the response body becomes generic and non-leaky.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
